### PR TITLE
fix semantics of CloseableResultSetIterator

### DIFF
--- a/src/test/scala/org/phasanix/dbshim/DbTest.scala
+++ b/src/test/scala/org/phasanix/dbshim/DbTest.scala
@@ -26,4 +26,30 @@ class DbTest extends FunSuite with ShouldMatchers {
     val x = it.toSeq.last // read to end
     conn.isClosed shouldBe true
   }
+
+  test("repeated calls to resultset iterator hasNext should be idempotent") {
+    implicit val conn = DbFixture.getConnection
+    val it = Db.autocloseQuery("select  * from TEST.A")
+
+    // The iterator implementation should be correct in the case of
+    // repeated calls to hasNext, which will result from the call to
+    // isEmpty followed by reading the whole iterator.
+
+    it.isEmpty shouldBe false
+    it.isEmpty shouldBe false
+    it.length shouldBe 4
+  }
+
+  test("repeated calls to resultset iterator next should not break iteration") {
+    implicit val conn = DbFixture.getConnection
+    val it = Db.autocloseQuery("select * from TEST.A")
+
+    // Repeated calls to ResultSet.next() should not happen in real code
+    // without interleaved calls to hasNext(), but it should still work
+    // if we happen to know how many rows there are are going to be.
+
+    (0 until 4).foreach(_ => it.next())
+    it.hasNext shouldBe false
+    conn.isClosed shouldBe true
+  }
 }


### PR DESCRIPTION
Now works correctly when calls to hasNext/next are not interleaved.
